### PR TITLE
Fix incorrect data type in format string

### DIFF
--- a/pkg/tc/server/getty_session_manager.go
+++ b/pkg/tc/server/getty_session_manager.go
@@ -4,14 +4,9 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-)
 
-import (
 	getty "github.com/apache/dubbo-getty"
 	"github.com/pkg/errors"
-)
-
-import (
 	"github.com/transaction-wg/seata-golang/pkg/base/meta"
 	"github.com/transaction-wg/seata-golang/pkg/base/model"
 	"github.com/transaction-wg/seata-golang/pkg/base/protocal"
@@ -192,7 +187,7 @@ func (manager *GettySessionManager) GetGettySession(resourceID string, clientID 
 
 	clientIDInfo := strings.Split(clientID, ClientIDSplitChar)
 	if clientIDInfo == nil || len(clientIDInfo) != 3 {
-		return nil, errors.Errorf("Invalid RpcRemoteClient ID:%d", clientID)
+		return nil, errors.Errorf("Invalid RpcRemoteClient ID: %s", clientID)
 	}
 	targetApplicationID := clientIDInfo[0]
 	targetIP := clientIDInfo[1]


### PR DESCRIPTION

### Ⅰ. Describe what this PR did

The string type should use %s, otherwise may get this error:

```
getty_session_manager.go:195:15: Errorf format %d has arg clientID of wrong type string
```

### Ⅱ. Does this pull request fix one issue?


### Ⅲ. Why don't you add test cases (unit test/integration test)? 


### Ⅳ. Describe how to verify it


### Ⅴ. Special notes for reviews
