### PR TITLE
fix: #72 cpu占用率100%

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ cmd/tc/cmd
 cmd/tc/tc
 cmd/tc/trace.out
 dist/tc
+dist/cmd
+dist/seata.log
+examples/

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,7 +1,9 @@
 package client
 
 import (
-	"log"
+	"context"
+	"fmt"
+	"time"
 
 	"google.golang.org/grpc"
 
@@ -15,11 +17,15 @@ import (
 // Init init resource manager，init transaction manager, expose a port to listen tc
 // call back request.
 func Init(config *config.Configuration) {
-	conn, err := grpc.Dial(config.ServerAddressing,
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	defer cancel()
+
+	conn, err := grpc.DialContext(ctx, config.ServerAddressing,
 		grpc.WithInsecure(),
+		grpc.WithBlock(),
 		grpc.WithKeepaliveParams(config.GetClientParameters()))
 	if err != nil {
-		log.Fatalf("did not connect: %v", err)
+		panic(fmt.Errorf("did not connect: %v", err))
 	}
 
 	resourceManagerClient := apis.NewResourceManagerServiceClient(conn)

--- a/pkg/client/rm/resource_manager.go
+++ b/pkg/client/rm/resource_manager.go
@@ -72,11 +72,19 @@ func GetResourceManager() *ResourceManager {
 }
 
 func (manager *ResourceManager) branchCommunicate() {
+	var count int
+
 	for {
 		ctx := metadata.AppendToOutgoingContext(context.Background(), "addressing", manager.addressing)
 		stream, err := manager.rpcClient.BranchCommunicate(ctx)
-		if err != nil {
+		if err != nil && count < 3 {
+			count++
+			log.Info(err)
 			continue
+		}
+
+		if count == 3 {
+			panic(err)
 		}
 
 		done := make(chan bool)
@@ -92,8 +100,6 @@ func (manager *ResourceManager) branchCommunicate() {
 					if err != nil {
 						return
 					}
-				default:
-					continue
 				}
 			}
 		}, nil)

--- a/pkg/tc/server/callback_message_queue.go
+++ b/pkg/tc/server/callback_message_queue.go
@@ -10,12 +10,15 @@ type CallbackMessageQueue struct {
 	lock *sync.Mutex
 
 	queue []*apis.BranchMessage
+
+	notify chan struct{}
 }
 
 func NewCallbackMessageQueue() *CallbackMessageQueue {
 	return &CallbackMessageQueue{
-		queue: make([]*apis.BranchMessage, 0),
-		lock:  &sync.Mutex{},
+		queue:  make([]*apis.BranchMessage, 0),
+		lock:   &sync.Mutex{},
+		notify: make(chan struct{}, 3),
 	}
 }
 
@@ -23,14 +26,19 @@ func (p *CallbackMessageQueue) Enqueue(msg *apis.BranchMessage) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 	p.queue = append(p.queue, msg)
+
+	p.notify <- struct{}{}
 }
 
 func (p *CallbackMessageQueue) Dequeue() *apis.BranchMessage {
 	p.lock.Lock()
 	defer p.lock.Unlock()
+
+	<-p.notify
 	if len(p.queue) == 0 {
 		return nil
 	}
+
 	var msg *apis.BranchMessage
 	msg, p.queue = p.queue[0], p.queue[1:]
 	return msg


### PR DESCRIPTION
ref: https://github.com/seata-golang/seata-golang/issues/<issueID>

### Ⅰ. Describe what this PR did

fix some bugs

### Ⅱ. Does this pull request fix one issue?

fix: #72 cpu占用率100%

### Ⅲ. Why don't you add test cases (unit test/integration test)? 

no need

### Ⅳ. Describe how to verify it

run http exmaples `aggregation_svc`,  and check the cpu usage percent, it would't rush to 100% any more 

### Ⅴ. Special notes for reviews

1. 使用grpc.DialContext的方式创建连接，并设置ctx的超时时间
2. RM的branchCommunicate方法出现3次错误（或许可以改为配置），主动panic，避免空循环耗费cpu
3. 去掉select{} 中的default部分，golang里面select等待io事件就好，不像switch需要default，如果设置了default，这里也会导致空转。
