### PR TITLE
bugfix: TC config parameters default value bug & optimize TC config.yml table names

### DIFF
--- a/cmd/profiles/dev/config.yml
+++ b/cmd/profiles/dev/config.yml
@@ -26,8 +26,8 @@ storage:
 #  inmemory:
   mysql:
     dsn: "root:123456@tcp(127.0.0.1:3306)/seata?timeout=1s&readTimeout=1s&writeTimeout=1s&parseTime=true&loc=Local&charset=utf8mb4,utf8"
-    globaltable: global_table2
-    branchtable: branch_table2
+    globaltable: global_table
+    branchtable: branch_table
     locktable: lock_table
     maxopenconnections: 100
     maxidleconnections: 20

--- a/pkg/tc/storage/driver/mysql/mysql.go
+++ b/pkg/tc/storage/driver/mysql/mysql.go
@@ -88,17 +88,17 @@ func FromParameters(parameters map[string]interface{}) (storage.Driver, error) {
 
 	globalTable := parameters["globaltable"]
 	if globalTable == nil {
-		dsn = "global_table"
+		globalTable = "global_table"
 	}
 
 	branchTable := parameters["branchtable"]
-	if globalTable == nil {
-		dsn = "branch_table"
+	if branchTable == nil {
+		branchTable = "branch_table"
 	}
 
 	lockTable := parameters["locktable"]
-	if globalTable == nil {
-		dsn = "global_table"
+	if lockTable == nil {
+		lockTable = "lock_table"
 	}
 
 	queryLimit := 100
@@ -140,7 +140,7 @@ func FromParameters(parameters map[string]interface{}) (storage.Driver, error) {
 	switch mi := mi.(type) {
 	case string:
 		var err error
-		maxOpenConnections, err = strconv.Atoi(mi)
+		maxIdleConnections, err = strconv.Atoi(mi)
 		if err != nil {
 			log.Error("the maxidleconnections parameter should be a integer")
 		}

--- a/pkg/tc/storage/driver/pgsql/pgsql.go
+++ b/pkg/tc/storage/driver/pgsql/pgsql.go
@@ -88,17 +88,17 @@ func FromParameters(parameters map[string]interface{}) (storage.Driver, error) {
 
 	globalTable := parameters["globaltable"]
 	if globalTable == nil {
-		dsn = "global_table"
+		globalTable = "global_table"
 	}
 
 	branchTable := parameters["branchtable"]
-	if globalTable == nil {
-		dsn = "branch_table"
+	if branchTable == nil {
+		branchTable = "branch_table"
 	}
 
 	lockTable := parameters["locktable"]
-	if globalTable == nil {
-		dsn = "global_table"
+	if lockTable == nil {
+		lockTable = "global_table"
 	}
 
 	queryLimit := 100
@@ -140,7 +140,7 @@ func FromParameters(parameters map[string]interface{}) (storage.Driver, error) {
 	switch mi := mi.(type) {
 	case string:
 		var err error
-		maxOpenConnections, err = strconv.Atoi(mi)
+		maxIdleConnections, err = strconv.Atoi(mi)
 		if err != nil {
 			log.Error("the maxidleconnections parameter should be a integer")
 		}

--- a/pkg/tc/storage/driver/pgsql/pgsql.go
+++ b/pkg/tc/storage/driver/pgsql/pgsql.go
@@ -98,7 +98,7 @@ func FromParameters(parameters map[string]interface{}) (storage.Driver, error) {
 
 	lockTable := parameters["locktable"]
 	if lockTable == nil {
-		lockTable = "global_table"
+		lockTable = "lock_table"
 	}
 
 	queryLimit := 100


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
Fix TC config parameters default value bug.
According to scripts/server/db/mysql.sql, change TC config.yml mysql table names to avoid newbie confused.

### Ⅱ. Does this pull request fix one issue?
no

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
no need

### Ⅳ. Describe how to verify it
Run the TC using mysql or pgsql without config.yml indicating "globaltable", it won`t go wrong now.

### Ⅴ. Special notes for reviews
nothing