### PR TITLE
remove unnecessary PhaseOneFailed check in doGloablCommit

### DIFF
--- a/pkg/tc/server/transaction_coordinator.go
+++ b/pkg/tc/server/transaction_coordinator.go
@@ -644,7 +644,7 @@ func (tc *TransactionCoordinator) BranchCommunicate(stream apis.ResourceManagerS
 				if !ok {
 					return
 				}
-			case msg := <- q:
+			case msg := <-q:
 				err := stream.Send(msg)
 				if err != nil {
 					return

--- a/pkg/tc/server/transaction_coordinator.go
+++ b/pkg/tc/server/transaction_coordinator.go
@@ -238,15 +238,6 @@ func (tc *TransactionCoordinator) doGlobalCommit(gt *model.GlobalTransaction, re
 	}
 
 	for bs := range gt.BranchSessions {
-		if bs.Status == apis.PhaseOneFailed {
-			tc.resourceDataLocker.ReleaseLock(bs)
-			delete(gt.BranchSessions, bs)
-			err = tc.holder.RemoveBranchSession(gt.GlobalSession, bs)
-			if err != nil {
-				return false, err
-			}
-			continue
-		}
 		branchStatus, err1 := tc.branchCommit(bs)
 		if err1 != nil {
 			log.Errorf("exception committing branch xid=%d branchID=%d, err: %v", bs.GetXID(), bs.BranchID, err1)


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
PhaseOneFailed check here is unnecessary because it's for Saga mode and currently seata-golang does not support Saga.
```golang
	if gt.IsSaga() {
		return false, status.Errorf(codes.Unimplemented, "method Commit not supported saga mode")
	}
```

### Ⅱ. Does this pull request fix one issue?
None


### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Not necessary


### Ⅳ. Describe how to verify it
remove PhaseOneFailed check from doGlobalCommit function


### Ⅴ. Special notes for reviews
None