### PR TITLE
fix BusinessActionContext .branchID from string to int64

### DIFF
--- a/pkg/client/base/context/business_action_context.go
+++ b/pkg/client/base/context/business_action_context.go
@@ -4,7 +4,7 @@ package context
 type BusinessActionContext struct {
 	*RootContext
 	XID           string
-	BranchID      string
+	BranchID      int64
 	ActionName    string
 	ActionContext map[string]interface{}
 }

--- a/pkg/client/tcc/proxy.go
+++ b/pkg/client/tcc/proxy.go
@@ -3,7 +3,6 @@ package tcc
 import (
 	"encoding/json"
 	"reflect"
-	"strconv"
 
 	gxnet "github.com/dubbogo/gost/net"
 	"github.com/pkg/errors"
@@ -123,7 +122,7 @@ func proceed(methodDesc *proxy.MethodDescriptor, ctx *ctx.BusinessActionContext,
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
-	ctx.BranchID = strconv.FormatInt(branchID, 10)
+	ctx.BranchID = branchID
 
 	args = append(args, ctx)
 	returnValues := proxy.Invoke(methodDesc, nil, args)

--- a/pkg/client/tcc/tcc_resource_manager.go
+++ b/pkg/client/tcc/tcc_resource_manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/opentrx/seata-golang/v2/pkg/apis"
 	ctx "github.com/opentrx/seata-golang/v2/pkg/client/base/context"
@@ -134,7 +133,7 @@ func getBusinessActionContext(xid string, branchID int64, resourceID string, app
 
 	businessActionContext := &ctx.BusinessActionContext{
 		XID:           xid,
-		BranchID:      strconv.FormatInt(branchID, 10),
+		BranchID:      branchID,
 		ActionName:    resourceID,
 		ActionContext: actionContextMap,
 	}


### PR DESCRIPTION
ref: https://github.com/seata-golang/seata-golang/issues/85

### Ⅰ. Describe what this PR did
Refactor BusinessActionContext.BranchID from string to int64

### Ⅱ. Does this pull request fix one issue?
yes. #85 

