### PR TITLE
Automatically create tables for tc on pgsql

### DIFF
--- a/pkg/tc/storage/driver/pgsql/pgsql.go
+++ b/pkg/tc/storage/driver/pgsql/pgsql.go
@@ -48,6 +48,58 @@ const (
 
 	QueryRowKey = `select xid, transaction_id, branch_id, resource_id, table_name, pk, row_key, gmt_create, gmt_modified
 		from %s where %s order by gmt_create asc`
+
+	CreateGlobalTable = `
+		CREATE TABLE IF NOT EXISTS %s
+		(
+		  addressing varchar(128) NOT NULL,
+		  xid varchar(128) NOT NULL,
+		  transaction_id bigint DEFAULT NULL,
+		  transaction_name varchar(128) DEFAULT NULL,
+		  timeout int DEFAULT NULL,
+		  begin_time bigint DEFAULT NULL,
+		  status int NOT NULL,
+		  active bool NOT NULL,
+		  gmt_create timestamp DEFAULT NULL,
+		  gmt_modified timestamp DEFAULT NULL,
+		  PRIMARY KEY (xid)
+		);
+		CREATE INDEX IF NOT EXISTS idx_gmt_modified_status ON %s(gmt_modified, status);
+		CREATE INDEX IF NOT EXISTS idx_transaction_id ON %s(transaction_id);`
+
+	CreateBranchTable = `
+		CREATE TABLE IF NOT EXISTS %s
+		(
+		  addressing varchar(128) NOT NULL,
+		  xid varchar(128) NOT NULL,
+		  branch_id bigint NOT NULL,
+		  transaction_id bigint DEFAULT NULL,
+		  resource_id varchar(256) DEFAULT NULL,
+		  lock_key VARCHAR(1000),
+		  branch_type varchar(8) DEFAULT NULL,
+		  status int DEFAULT NULL,
+		  application_data varchar(2000) DEFAULT NULL,
+		  gmt_create timestamp DEFAULT NULL,
+		  gmt_modified timestamp DEFAULT NULL,
+		  PRIMARY KEY (branch_id)
+		);
+		CREATE INDEX IF NOT EXISTS idx_xid ON %s(xid);`
+
+	CreateLockTable = `
+		CREATE TABLE IF NOT EXISTS %s
+		(
+			row_key        VARCHAR(256) NOT NULL,
+			xid            VARCHAR(96),
+			transaction_id BIGINT,
+			branch_id      BIGINT       NOT NULL,
+			resource_id    VARCHAR(256),
+			table_name     VARCHAR(64),
+			pk             VARCHAR(36),
+			gmt_create     TIMESTAMP,
+			gmt_modified   TIMESTAMP,
+			PRIMARY KEY (row_key)
+		);
+		CREATE INDEX IF NOT EXISTS idx_branch_id ON %s(branch_id);`
 )
 
 func init() {
@@ -195,6 +247,19 @@ func New(params DriverParameters) (storage.Driver, error) {
 	engine.SetMaxOpenConns(params.MaxOpenConnections)
 	engine.SetMaxIdleConns(params.MaxIdleConnections)
 	engine.SetConnMaxLifetime(params.MaxLifeTime)
+
+	_, err = engine.Exec(fmt.Sprintf(CreateGlobalTable, params.GlobalTable, params.GlobalTable, params.GlobalTable))
+	if err != nil {
+		return nil, err
+	}
+	_, err = engine.Exec(fmt.Sprintf(CreateBranchTable, params.BranchTable, params.BranchTable))
+	if err != nil {
+		return nil, err
+	}
+	_, err = engine.Exec(fmt.Sprintf(CreateLockTable, params.LockTable, params.LockTable))
+	if err != nil {
+		return nil, err
+	}
 
 	return &driver{
 		engine:      engine,

--- a/pkg/tc/storage/driver/pgsql/pgsql.go
+++ b/pkg/tc/storage/driver/pgsql/pgsql.go
@@ -91,7 +91,7 @@ const (
 			row_key        VARCHAR(256) NOT NULL,
 			xid            VARCHAR(96),
 			transaction_id BIGINT,
-			branch_id      BIGINT       NOT NULL,
+			branch_id      BIGINT NOT NULL,
 			resource_id    VARCHAR(256),
 			table_name     VARCHAR(64),
 			pk             VARCHAR(36),


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
Automatically create tables for tc on pgsql if those tables do not exist

### Ⅱ. Does this pull request fix one issue?
no

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
Make seata-golang easier to use

### Ⅳ. Describe how to verify it
Drop global_table, branch_table and lock_table on pgsql, then go build tc, and run it with storage.pgsql config

### Ⅴ. Special notes for reviews
nothing