### PR TITLE
proxy return values do not need to be exported

### DIFF
--- a/pkg/client/proxy/service.go
+++ b/pkg/client/proxy/service.go
@@ -99,11 +99,6 @@ func describeMethod(method reflect.Method) *MethodDescriptor {
 	// returnValuesType
 	for num := 0; num < outNum; num++ {
 		returnValuesType = append(returnValuesType, methodType.Out(num))
-		// need not be a pointer.
-		if !isExportedOrBuiltinType(methodType.Out(num)) {
-			log.Errorf("reply type of method %s not exported{%v}", methodName, methodType.Out(num))
-			return nil
-		}
 	}
 
 	return &MethodDescriptor{


### PR DESCRIPTION
### Ⅰ. Describe what this PR did
remove exported check for proxy service returnValuesType

### Ⅱ. Does this pull request fix one issue?
none

### Ⅲ. Why don't you add test cases (unit test/integration test)? 
already there

### Ⅳ. Describe how to verify it
run TM and RM client and  set proxy service function to return values of unexported type

### Ⅴ. Special notes for reviews
none